### PR TITLE
adding --git-public since most users will want that at the workshop

### DIFF
--- a/jx/jx-cluster-tekton-demo.md
+++ b/jx/jx-cluster-tekton-demo.md
@@ -72,7 +72,7 @@ jx create cluster gke -n jx-rocks -p $PROJECT -r us-east1 \
     -m n1-standard-4 --min-num-nodes 1 --max-num-nodes 2 \
     --default-admin-password=admin \
     --default-environment-prefix jx-rocks --git-provider-kind github \
-    --namespace $NAMESPACE --prow --tekton --skip-login
+    --namespace $NAMESPACE --prow --tekton --skip-login --git-public
 ```
 
 


### PR DESCRIPTION
Modified the `create cluster` command to use `--git-public` as most users will want to have this for just playing around.