### PR TITLE
Fix jx workshop copypastables from "cat | sed | tee" to "sed -i" patterns

### DIFF
--- a/jx/gitops.md
+++ b/jx/gitops.md
@@ -84,7 +84,7 @@ While there is no doubt among developers where to store the files they create, t
 ## Git Is The Only Source Of Truth
 
 ```bash
-cat main.go | sed -e "s@golang http@GitOps@g" | tee main.go
+sed -e "s@golang http@GitOps@g" -i main.go
 
 git add .
 
@@ -363,9 +363,8 @@ cd environment-jx-rocks-staging/env
 CM_ADDR=$(kubectl get ing chartmuseum \
     -o jsonpath="{.spec.rules[0].host}")
 
-cat requirements.yaml | sed -e \
-    "s@http://jenkins-x-chartmuseum:8080@http://$CM_ADDR@g" \
-    | tee requirements.yaml
+sed -e "s@http://jenkins-x-chartmuseum:8080@http://$CM_ADDR@g" \
+    -i requirements.yaml
 ```
 
 

--- a/jx/jx-advanced-pipeline-demo.md
+++ b/jx/jx-advanced-pipeline-demo.md
@@ -47,14 +47,14 @@ export REGISTRY_OWNER=[...]
 ## In case you messed it up
 
 ```bash
-cat charts/go-demo-6/Makefile | sed -e "s@devops-26@$REGISTRY_OWNER@g" \
-    | tee charts/go-demo-6/Makefile
+sed -e "s@devops-26@$REGISTRY_OWNER@g" \
+    -i charts/go-demo-6/Makefile
 
-cat charts/preview/Makefile | sed -e "s@devops-26@$REGISTRY_OWNER@g" \
-    | tee charts/preview/Makefile
+sed -e "s@devops-26@$REGISTRY_OWNER@g" \
+    -i charts/preview/Makefile
 
-cat skaffold.yaml | sed -e "s@devops-26@$REGISTRY_OWNER@g" \
-    | tee skaffold.yaml
+sed -e "s@devops-26@$REGISTRY_OWNER@g" \
+    -i skaffold.yaml
 
 git add . && git commit -m "Registry owner" && git push
 ```
@@ -532,8 +532,8 @@ jx step syntax validate pipeline
 
 cat Dockerfile
 
-cat Dockerfile | sed -e 's@/bin/ /@/bin/go-demo-6_linux /go-demo-6@g' \
-    | tee Dockerfile
+sed -e 's@/bin/ /@/bin/go-demo-6_linux /go-demo-6@g' \
+    -i Dockerfile
 
 git add .
 

--- a/jx/jx-apps-demo.md
+++ b/jx/jx-apps-demo.md
@@ -229,8 +229,8 @@ ls -1 env
 
 cat env/nexus/values.yaml
 
-cat env/nexus/values.yaml | sed -e 's@enabled: true@enabled: false@g' \
-    | tee env/nexus/values.yaml
+sed -e 's@enabled: true@enabled: false@g' \
+    -i env/nexus/values.yaml
 ```
 
 
@@ -421,9 +421,9 @@ cp -r env/istio-init env/istio
 ```bash
 cat env/istio/templates/app.yaml
 
-cat env/istio/templates/app.yaml | sed -e 's@istio-init@istio@g' \
-    | sed -e 's@initialize Istio CRDs@install Istio@g' \
-    | tee env/istio/templates/app.yaml
+sed -e 's@istio-init@istio@g' \
+    -e 's@initialize Istio CRDs@install Istio@g' \
+    -i env/istio/templates/app.yaml
 
 cat env/requirements.yaml
 

--- a/jx/jx-buildpack-demo.md
+++ b/jx/jx-buildpack-demo.md
@@ -35,12 +35,12 @@ cp -R packs/go packs/go-mongo
 ---
 
 ```bash
-cat packs/go-mongo/charts/templates/deployment.yaml | sed -e \
+sed -e \
     's@ports:@env:\
         - name: DB\
           value: {{ template "fullname" . }}-db\
         ports:@g' \
-    | tee packs/go-mongo/charts/templates/deployment.yaml
+    -i packs/go-mongo/charts/templates/deployment.yaml
 
 echo "dependencies:
 - name: mongodb
@@ -72,18 +72,17 @@ ls -1 packs/go-mongo/preview
 
 cat packs/go-mongo/preview/requirements.yaml
 
-cat packs/go-mongo/preview/requirements.yaml \
-    | sed -e \
+sed -e \
     's@  # !! "alias@- name: mongodb\
   alias: preview-db\
   version: 5.3.0\
   repository:  https://kubernetes-charts.storage.googleapis.com\
 \
   # !! "alias@g' \
-    | tee packs/go-mongo/preview/requirements.yaml
+    -i packs/go-mongo/preview/requirements.yaml
 
 echo '
-' | tee -a packs/go-mongo/preview/requirements.yaml 
+' >> packs/go-mongo/preview/requirements.yaml
 ```
 
 
@@ -157,9 +156,8 @@ kubectl -n jx-staging describe pod -l app=jx-staging-go-demo-6
 
 cat charts/go-demo-6/values.yaml
 
-cat charts/go-demo-6/values.yaml | sed -e \
-    's@probePath: /@probePath: /demo/hello?health=true@g' \
-    | tee charts/go-demo-6/values.yaml
+sed -e 's@probePath: /@probePath: /demo/hello?health=true@g' \
+    -i charts/go-demo-6/values.yaml
 
 echo '
   probePath: /demo/hello?health=true' \

--- a/jx/jx-cluster-demo-deployment.md
+++ b/jx/jx-cluster-demo-deployment.md
@@ -191,19 +191,19 @@ jx get activity --filter jx-recreate --watch
 
 cd jx-recreate
 
-cat charts/jx-recreate/templates/deployment.yaml | sed -e \
+sed -e \
     's@  replicas:@  strategy:\
     type: Recreate\
-  replicas:@g' | tee charts/jx-recreate/templates/deployment.yaml
+  replicas:@g' \
+    -i charts/jx-recreate/templates/deployment.yaml
 ```
 
 
 ## Setting The Scene (Recreate)
 
 ```bash
-cat charts/jx-recreate/values.yaml \
-    | sed -e 's@replicaCount: 1@replicaCount: 5@g' \
-    | tee charts/jx-recreate/values.yaml
+sed -e 's@replicaCount: 1@replicaCount: 5@g' \
+    -i charts/jx-recreate/values.yaml
 
 git add . && git commit -m "Recreate"
 
@@ -225,9 +225,8 @@ jx get activity --filter jx-rolling --watch
 
 cd jx-rolling
 
-cat charts/jx-rolling/values.yaml \
-    | sed -e 's@replicaCount: 1@replicaCount: 5@g' \
-    | tee charts/jx-rolling/values.yaml
+sed -e 's@replicaCount: 1@replicaCount: 5@g' \
+    -i charts/jx-rolling/values.yaml
 ```
 
 

--- a/jx/jx-cluster-demo-knative.md
+++ b/jx/jx-cluster-demo-knative.md
@@ -87,12 +87,12 @@ curl $ADDR
 ```bash
 cd jx-knative
 
-cat charts/jx-knative/templates/ksvc.yaml | sed -e \
+sed -e \
     's@revisionTemplate:@revisionTemplate:\
         metadata:\
           annotations:\
             autoscaling.knative.dev/maxScale: "5"@g' \
-    | tee charts/jx-knative/templates/ksvc.yaml
+    -i charts/jx-knative/templates/ksvc.yaml
 ```
 
 

--- a/jx/jx-deployment-demo-short.md
+++ b/jx/jx-deployment-demo-short.md
@@ -90,7 +90,7 @@ cd jx-recreate
 
 kubectl --namespace jx-staging get pods --selector app=jx-jx-recreate
 
-cat main.go | sed -e "s@example@recreate@g" | tee main.go
+sed -e "s@example@recreate@g" -i main.go
 
 git add . && git commit -m "Recreate strategy" && git push
 
@@ -148,7 +148,7 @@ done
 ```bash
 cd jx-rolling
 
-cat main.go | sed -e "s@example@rolling update@g" | tee main.go
+sed -e "s@example@rolling update@g" -i main.go
 
 git add . && git commit -m "Rolling update" && git push
 
@@ -214,7 +214,7 @@ done
 ```bash
 cd jx-canary
 
-cat main.go | sed -e "s@example@canary@g" | tee main.go
+sed -e "s@example@canary@g" -i main.go
 
 git add . && git commit -m "Canary"
 

--- a/jx/jx-deployment-demo.md
+++ b/jx/jx-deployment-demo.md
@@ -136,15 +136,14 @@ cd ..
 ```bash
 cd jx-progressive
 
-cat charts/jx-progressive/values.yaml | sed -e \
-    's@replicaCount: 1@replicaCount: 3@g' \
-    | tee charts/jx-progressive/values.yaml
+sed -e 's@replicaCount: 1@replicaCount: 3@g' \
+    -i charts/jx-progressive/values.yaml
 
-cat charts/jx-progressive/templates/deployment.yaml | sed -e \
+sed -e \
     's@  replicas:@  strategy:\
     type: Recreate\
   replicas:@g' \
-    | tee charts/jx-progressive/templates/deployment.yaml
+    -i charts/jx-progressive/templates/deployment.yaml
 ```
 
 
@@ -201,7 +200,7 @@ git push
 
 kubectl --namespace jx-staging get ing
 
-cat main.go | sed -e "s@example@recreate@g" | tee main.go
+sed -e "s@example@recreate@g" -i main.go
 ```
 
 
@@ -286,11 +285,10 @@ done
 ## RollingUpdate Strategy
 
 ```bash
-cat charts/jx-progressive/templates/deployment.yaml | sed -e \
-    's@type: Recreate@type: RollingUpdate@g' \
-    | tee charts/jx-progressive/templates/deployment.yaml
+sed -e 's@type: Recreate@type: RollingUpdate@g' \
+    -i charts/jx-progressive/templates/deployment.yaml
 
-cat main.go | sed -e "s@recreate@rolling update@g" | tee main.go
+sed -e "s@recreate@rolling update@g" -i main.go
 
 git add .
 
@@ -594,7 +592,7 @@ kubectl --namespace $NAMESPACE-staging get virtualservices.networking.istio.io
 kubectl --namespace istio-system logs \
     --selector app.kubernetes.io/name=flagger
 
-cat main.go | sed -e "s@rolling update@progressive@g" | tee main.go
+sed -e "s@rolling update@progressive@g" -i main.go
 ```
 
 

--- a/jx/jx-dev-demo.md
+++ b/jx/jx-dev-demo.md
@@ -129,9 +129,9 @@ echo 'unittest:
 	CGO_ENABLED=$(CGO_ENABLED) $(GO) test --run UnitTest -v
 ' | tee -a Makefile
 
-cat watch.sh | sed -e \
+sed -e \
     's@linux \&\& skaffold@linux \&\& make unittest \&\& skaffold@g' \
-    | tee watch.sh
+    -i watch.sh
 
 jx sync --daemon
 
@@ -162,11 +162,11 @@ chmod +x watch.sh
 ```bash
 curl "$URL/demo/hello"
 
-cat main.go | sed -e \
-    's@hello, world@hello, devpod with tests@g' | tee main.go
+sed -e 's@hello, world@hello, devpod with tests@g' \
+    -i main.go
 
-cat main_test.go | sed -e \
-    's@hello, world@hello, devpod with tests@g' | tee main_test.go
+sed -e 's@hello, world@hello, devpod with tests@g' \
+    -i main_test.go
 ```
 
 * Go back to the second terminal and observe the output

--- a/jx/jx-env-tekton-demo.md
+++ b/jx/jx-env-tekton-demo.md
@@ -190,14 +190,13 @@ cat integration_test.go
 ```bash
 cat jenkins-x.yml
 
-cat jenkins-x.yml \
-    | sed -e \
+sed -e \
     's@pipelines: {}@pipelines:\
     release:\
       postBuild:\
         steps:\
         - command: make test@g' \
-    | tee jenkins-x.yml
+    -i jenkins-x.yml
 
 cat jenkins-x.yml
 ```

--- a/jx/jx-extension-demo.md
+++ b/jx/jx-extension-demo.md
@@ -47,14 +47,14 @@ export REGISTRY_OWNER=[...]
 ## In case you messed it up
 
 ```bash
-cat charts/go-demo-6/Makefile | sed -e "s@devops-26@$REGISTRY_OWNER@g" \
-    | tee charts/go-demo-6/Makefile
+sed -e "s@devops-26@$REGISTRY_OWNER@g" \
+    -i charts/go-demo-6/Makefile
 
-cat charts/preview/Makefile | sed -e "s@devops-26@$REGISTRY_OWNER@g" \
-    | tee charts/preview/Makefile
+sed -e "s@devops-26@$REGISTRY_OWNER@g" \
+    -i charts/preview/Makefile
 
-cat skaffold.yaml | sed -e "s@devops-26@$REGISTRY_OWNER@g" \
-    | tee skaffold.yaml
+sed -e "s@devops-26@$REGISTRY_OWNER@g" \
+    -i skaffold.yaml
 ```
 
 
@@ -101,13 +101,11 @@ jx get activities --filter go-demo-6 --watch
 ```bash
 git checkout -b extension
 
-cat charts/go-demo-6/values.yaml | sed -e \
-    's@replicaCount: 1@replicaCount: 3@g' \
-    | tee charts/go-demo-6/values.yaml
+sed -e 's@replicaCount: 1@replicaCount: 3@g' \
+    -i charts/go-demo-6/values.yaml
 
-cat functional_test.go | sed -e \
-    's@fmt.Sprintf("http://@fmt.Sprintf("@g' \
-    | tee functional_test.go
+sed -e 's@fmt.Sprintf("http://@fmt.Sprintf("@g' \
+    -i functional_test.go
 ```
 
 
@@ -118,8 +116,8 @@ cat functional_test.go | sed -e \
 ## Extending Build Pack Pipelines
 
 ```bash
-cat production_test.go | sed -e 's@fmt.Sprintf("http://@fmt.Sprintf("@g' \
-    | tee production_test.go
+sed -e 's@fmt.Sprintf("http://@fmt.Sprintf("@g' \
+    -i production_test.go
 
 echo "buildPack: go
 pipelineConfig:
@@ -127,7 +125,8 @@ pipelineConfig:
     pullRequest:
       build:
         preSteps:
-        - command: make unittest" | tee jenkins-x.yml
+        - command: make unittest" \
+    | tee jenkins-x.yml
 
 cat jenkins-x.yml
 ```
@@ -234,7 +233,7 @@ open "$PR_ADDR"
 
 ```bash
 # Repeat until `promote` extension is removed
-cat jenkins-x.yml | sed '$ d' | tee jenkins-x.yml
+sed -e '$ d' -i jenkins-x.yml
 
 git add . && git commit --message "Removed the silly test" && git push
 ```
@@ -266,14 +265,13 @@ curl https://raw.githubusercontent.com/jenkins-x-buildpacks/jenkins-x-kubernetes
 ## Extending Environment Pipelines
 
 ```bash
-cat jenkins-x.yml \
-    | sed -e \
+sed -e \
     's@pipelines: {}@pipelines:\
     release:\
       postBuild:\
         steps:\
         - command: echo "Running integ tests!!!"@g' \
-    | tee jenkins-x.yml
+    -i jenkins-x.yml
 
 cat jenkins-x.yml
 

--- a/jx/jx-pr-demo-short.md
+++ b/jx/jx-pr-demo-short.md
@@ -16,7 +16,7 @@ cd jx-go
 
 git checkout -b my-pr
 
-cat main.go | sed -e "s@http example@http PR@g" | tee main.go
+sed -e "s@http example@http PR@g" -i main.go
 
 git add . && git commit -m "This is a PR"
 

--- a/jx/jx-pr-demo.md
+++ b/jx/jx-pr-demo.md
@@ -47,14 +47,14 @@ export REGISTRY_OWNER=[...]
 ## In case you messed it up
 
 ```bash
-cat charts/go-demo-6/Makefile | sed -e "s@devops-26@$REGISTRY_OWNER@g" \
-    | tee charts/go-demo-6/Makefile
+sed -e "s@devops-26@$REGISTRY_OWNER@g" \
+    -i charts/go-demo-6/Makefile
 
-cat charts/preview/Makefile | sed -e "s@devops-26@$REGISTRY_OWNER@g" \
-    | tee charts/preview/Makefile
+sed -e "s@devops-26@$REGISTRY_OWNER@g" \
+    -i charts/preview/Makefile
 
-cat skaffold.yaml | sed -e "s@devops-26@$REGISTRY_OWNER@g" \
-    | tee skaffold.yaml
+sed -e "s@devops-26@$REGISTRY_OWNER@g" \
+    -i skaffold.yaml
 ```
 
 
@@ -70,11 +70,11 @@ cat skaffold.yaml | sed -e "s@devops-26@$REGISTRY_OWNER@g" \
 ```bash
 git checkout -b my-new-pr
 
-cat main.go | sed -e "s@hello, devpod with tests@hello, PR@g" \
-    | tee main.go
+sed -e "s@hello, devpod with tests@hello, PR@g" \
+    -i main.go
 
-cat main_test.go | sed -e "s@hello, devpod with tests@hello, PR@g" \
-    | tee main_test.go
+sed -e "s@hello, devpod with tests@hello, PR@g" \
+    -i main_test.go
 ```
 
 

--- a/jx/jx-serverless-apps-demo-talk.md
+++ b/jx/jx-serverless-apps-demo-talk.md
@@ -67,7 +67,7 @@ kubectl --namespace cd-staging get pods
 ```bash
 git checkout -b my-pr
 
-cat main.go | sed -e "s@example@Knative@g" | tee main.go
+sed -e "s@example@Knative@g" -i main.go
 
 git add . && git commit -m "Added something"
 

--- a/jx/jx-serverless-apps-demo.md
+++ b/jx/jx-serverless-apps-demo.md
@@ -181,13 +181,13 @@ kubectl run siege --image yokogawa/siege --generator "run-pod/v1" \
     && kubectl --namespace $NAMESPACE-staging get pods \
     --selector serving.knative.dev/service=jx-knative
 
-cat charts/jx-knative/templates/ksvc.yaml | sed -e \
+sed -e \
     's@revisionTemplate:@revisionTemplate:\
         metadata:\
           annotations:\
             autoscaling.knative.dev/target: "3"\
             autoscaling.knative.dev/maxScale: "5"@g' \
-    | tee charts/jx-knative/templates/ksvc.yaml
+    -i charts/jx-knative/templates/ksvc.yaml
 ```
 
 
@@ -239,10 +239,10 @@ kubectl --namespace $NAMESPACE-staging get pods \
 ## New Serverless Application
 
 ```bash
-cat charts/jx-knative/templates/ksvc.yaml | sed -e \
+sed -e \
     's@autoscaling.knative.dev/target: "3"@autoscaling.knative.dev/target: "3"\
             autoscaling.knative.dev/minScale: "1"@g' \
-    | tee charts/jx-knative/templates/ksvc.yaml
+    -i charts/jx-knative/templates/ksvc.yaml
 
 git add .
 

--- a/jx/jx-tekton-demo.md
+++ b/jx/jx-tekton-demo.md
@@ -65,7 +65,8 @@ echo "approvers:
 - $GH_APPROVER
 reviewers:
 - $GH_USER
-- $GH_APPROVER" | tee OWNERS
+- $GH_APPROVER" \
+    | tee OWNERS
 
 git commit -am "Added the other me"
 


### PR DESCRIPTION
Hello @vfarcic . As discussed on your enlightening workshop, there are issues with `cat FILE | sed | tee FILE` pattern that on some systems the later `tee` first overwrites the FILE and then `cat` prints the emptiness.

This PR aims to fix most of such cases I found in the `jx` directory: there is also one triple-pipe with `sed '$d'` that I did not fix because I did not quite understand it :-) but hopefully it can change into `sed -e '$d' -e '$d' -e '$d' -i FILE` if you deem fit.

Thanks for the teaching!